### PR TITLE
Bug/win10scaling

### DIFF
--- a/licecap/licecap_ui.cpp
+++ b/licecap/licecap_ui.cpp
@@ -215,8 +215,13 @@ void DoMouseCursor(LICE_IBitmap* sbm, HWND h, int xoffs, int yoffs)
       ICONINFO inf={0,};
       GetIconInfo(ci.hCursor,&inf);
 
-      int mousex = ci.ptScreenPos.x+xoffs;
-      int mousey = ci.ptScreenPos.y+yoffs;
+	  POINT curPos;
+	  curPos.x = ci.ptScreenPos.x;
+	  curPos.y = ci.ptScreenPos.y;
+	  LogicalToPhysicalPointForPerMonitorDPI(g_hwnd, &curPos);
+
+      int mousex = curPos.x+xoffs;
+      int mousey = curPos.y+yoffs;
 
       if ((g_prefs&4) && ((GetAsyncKeyState(VK_LBUTTON)&0x8000) || (GetAsyncKeyState(VK_RBUTTON)&0x8000)))
       {

--- a/licecap/licecap_ui.cpp
+++ b/licecap/licecap_ui.cpp
@@ -457,8 +457,16 @@ static void GetViewRectSize(int *w, int *h)
 {
   RECT r={0,0,320,240};
   GetWindowRect(GetDlgItem(g_hwnd,IDC_VIEWRECT),&r);
-  if (w) *w=r.right-r.left - 2;
-  if (h) *h=abs(r.bottom-r.top) - 2;
+
+  POINT wndLoc;
+  wndLoc.x = r.left;
+  wndLoc.y = r.top;
+  LogicalToPhysicalPointForPerMonitorDPI(g_hwnd, &wndLoc);
+
+  float sf = (float)wndLoc.x / (float)r.left;
+
+  if (w) *w=(r.right-r.left - 2) * sf;
+  if (h) *h=(abs(r.bottom-r.top) - 2) * sf;
 }
 
 void UpdateDimBoxes(HWND hwndDlg)
@@ -1162,9 +1170,17 @@ static WDL_DLGRET liceCapMainProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM
             {
               RECT r;
               GetWindowRect(GetDlgItem(hwndDlg,IDC_VIEWRECT),&r);
-              int bw = g_cap_bm->getWidth();
-              int bh = g_cap_bm->getHeight();
-              
+			  int bw = g_cap_bm->getWidth();
+			  int bh = g_cap_bm->getHeight();
+			  
+			  POINT wndLoc;
+			  wndLoc.x = r.left;
+			  wndLoc.y = r.top;
+			  LogicalToPhysicalPointForPerMonitorDPI(g_hwnd, &wndLoc);
+
+			  r.left = wndLoc.x;
+			  r.top = wndLoc.y;
+
               LICE_Clear(g_cap_bm,0);
               BitBlt(g_cap_bm->getDC(),0,0,bw,bh,hdc,r.left+1,r.top+1,SRCCOPY);
               ReleaseDC(h,hdc);


### PR DESCRIPTION
Closes #15 .

On Windows, when scaling has been turned on for a particular display, Licecap doesn't account for the difference between physical coordinates and logical ones and this has two effects.

1. The area that it records is wrongly offset by an amount that depends on the amount of scaling.
2. The mouse cursor is also rendered at the wrong location

This fix uses `LogicalToPhysicalPointForPerMonitorDPI` to convert the logical coordinates to physical ones when necessary. 

**Note**: I haven't tested this on OS X. 

For an overview of the issues causing this, here is an MSDN article

https://msdn.microsoft.com/en-us/library/windows/desktop/ee671605(v=vs.85).aspx
